### PR TITLE
Dutch translation

### DIFF
--- a/core/components/setinputoptions/lexicon/nl/default.inc.php
+++ b/core/components/setinputoptions/lexicon/nl/default.inc.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Dutch Lexicon Entries for SetInputOptions
+ *
+ * @package setinputoptions
+ * @subpackage lexicon
+ */
+
+$_lang['setinputoptions'] = 'Invoeropties beheren';
+
+$_lang['setinputoptions.menu.setinputoptions'] = 'Invoeropties';
+$_lang['setinputoptions.menu.setinputoptions_desc'] = 'Voeg invoeropties toe voor tv\'s.';
+
+$_lang['setinputoptions.global.search'] = 'Zoeken';
+
+$_lang['setinputoptions.group.groups'] = 'Groepen';
+$_lang['setinputoptions.group.intro_msg'] = 'Groepen beheren.';
+
+$_lang['setinputoptions.group.name'] = 'Naam';
+$_lang['setinputoptions.group.description'] = 'Groep maken';
+$_lang['setinputoptions.group.position'] = 'Position';
+$_lang['setinputoptions.group.create'] = 'Groep maken';
+$_lang['setinputoptions.group.update'] = 'Groep bewerken';
+$_lang['setinputoptions.group.edit_options'] = 'Invoeropties bewerken';
+$_lang['setinputoptions.group.remove'] = 'Groep verwijderen';
+$_lang['setinputoptions.group.remove_confirm'] = 'Weet je zeker dat je deze groep wilt verwijderen?';
+
+$_lang['setinputoptions.err.group_name_ae'] = 'Er bestaat al een groep met deze naam.';
+$_lang['setinputoptions.err.group_nf'] = 'Groep kan niet worden gevonden.';
+$_lang['setinputoptions.err.group_name_ns'] = 'Er is geen naam opgegeven.';
+$_lang['setinputoptions.err.group_remove'] = 'Er is een fout opgetreden bij het verwijderen van de groep.';
+$_lang['setinputoptions.err.group_save'] = 'Er is een fout opgetreden bij het opslaan van de groep.';
+
+$_lang['setinputoptions.inputoption.inputoption'] = 'Invoeropties';
+$_lang['setinputoptions.inputoption.intro_msg'] = 'Beheer de invoeropties voor groep: ';
+
+$_lang['setinputoptions.inputoption.name'] = "Naam";
+$_lang['setinputoptions.inputoption.alias'] = "Alias";
+$_lang['setinputoptions.inputoption.goBack'] = "Terug naar alle groepen";
+$_lang['setinputoptions.inputoption.type'] = "Type";
+$_lang['setinputoptions.inputoption.position'] = "Positie";
+$_lang['setinputoptions.inputoption.export'] = 'Exporteren';
+$_lang['setinputoptions.inputoption.exportMsg'] = 'Als je op \'Ja\' klikt, wordt er een CSV-bestand gegenereerd met daarin alle invoeropties uit deze groep. Met dit bestand kun je de invoeropties in andere groepen importeren. Het genereren van het bestand kan even duren als je veel invoeropties hebt.';
+$_lang['setinputoptions.inputoption.create'] = 'Invoeroptie toevoegen';
+$_lang['setinputoptions.inputoption.update'] = 'Invoeroptie bewerken';
+$_lang['setinputoptions.inputoption.edit_options'] = 'Invoeroptie bewerken';
+$_lang['setinputoptions.inputoption.remove'] = 'Invoeroptie verwijderen';
+$_lang['setinputoptions.inputoption.remove_confirm'] = 'Weet je zeker dat je deze invoeroptie wilt verwijderen?';
+$_lang['setinputoptions.inputoption.duplicate'] = 'Invoeroptie dupliceren';
+$_lang['setinputoptions.inputoption.duplicate_confirm'] = 'Weet je zeker dat je deze invoeroptie wilt dupliceren?';
+$_lang['setinputoptions.err.inputoption.save'] = 'Er is een fout opgetreden bij het opslaan van de invoeroptie.';


### PR DESCRIPTION
There were some things I ran into when translating this:
- What are the differences between
  `$_lang['setinputoptions.inputoption.update'] = 'Update an input option';` and
  `$_lang['setinputoptions.inputoption.edit_options'] = 'Edit input option';`? And are there any differences between 'update' and 'edit'? I have now used the same translation for both.
- I've translated 'Input Options' to 'invoeropties'. The MODX translation is 'Invoer Optie Waarden', but that's misspelled. Also for non-technical users who are going to use the Input Options add-on in my case, it's more understandable to translate the whole add-on from 'Set Input Options' to 'Invoeropties beheren' and 'Input Options' to 'invoeropties'.

If you disagree, please let me know!
